### PR TITLE
Integrate new paper search UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="https://cdn.tailwindcss.com"></script>
     <title>Vite + React</title>
   </head>
   <body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "lucide-react": "^0.513.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -2233,6 +2234,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.513.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.513.0.tgz",
+      "integrity": "sha512-CJZKq2g8Y8yN4Aq002GahSXbG2JpFv9kXwyiOAMvUBv7pxeOFHUWKB0mO7MiY4ZVFCV4aNjv2BJFq/z3DgKPQg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/minimatch": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "lucide-react": "^0.513.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,46 +1,6 @@
-import { useState } from 'react'
-import './App.css'
-import SearchBar from './components/SearchBar.jsx'
-import SearchOptions from './components/SearchOptions.jsx'
-import PaperList from './components/PaperList.jsx'
-import ChatPanel from './components/ChatPanel.jsx'
+import PaperSearchUI from './PaperSearchUI.jsx';
 
-function App() {
-  const [options, setOptions] = useState({})
-  const [papers, setPapers] = useState([])
-  const [loading, setLoading] = useState(false)
-  const [selectedPaper, setSelectedPaper] = useState(null)
-
-  const handleSearch = async ({ query, mode }) => {
-    setLoading(true)
-    setSelectedPaper(null)
-    try {
-      const params = new URLSearchParams({
-        query,
-        year_from: options.yearFrom || 2020,
-        year_to: options.yearTo || 2025,
-        limit: options.numPapers || 10,
-      })
-      const res = await fetch(`/api/search?${params}`)
-      const data = await res.json()
-      setPapers(data)
-    } catch (e) {
-      console.error(e)
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  return (
-    <div className="App">
-      <h1>論文検索</h1>
-      <SearchBar onSearch={handleSearch} />
-      <SearchOptions onChange={setOptions} />
-      {loading && <p>検索中...</p>}
-      <PaperList papers={papers} onSelect={setSelectedPaper} />
-      <ChatPanel paper={selectedPaper} />
-    </div>
-  )
+export default function App() {
+  return <PaperSearchUI />;
 }
 
-export default App

--- a/frontend/src/PaperSearchUI.jsx
+++ b/frontend/src/PaperSearchUI.jsx
@@ -143,22 +143,78 @@ const PaperSearchUI = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="bg-white shadow-sm border-b">
-        <div className="max-w-6xl mx-auto px-4 py-4">
-          <div className="flex items-center space-x-4">
+    <div className="min-h-screen bg-gray-50 flex">
+      {sidebarOpen ? (
+        <aside className="w-56 bg-white border-r flex flex-col relative">
+          <div className="p-4 flex-1 space-y-2">
             <button
               type="button"
-              onClick={resetSearch}
-              className="flex items-center space-x-2 focus:outline-none"
+              onClick={() => setViewMode('results')}
+              className={`w-full text-left px-3 py-2 rounded-md text-sm font-medium ${
+                viewMode === 'results' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'
+              }`}
             >
-              <FileText className="w-8 h-8 text-blue-600" />
-              <h1 className="text-2xl font-bold text-gray-800">Paper Search</h1>
+              検索結果
             </button>
-            <div className="text-sm text-gray-500">学術論文検索エンジン</div>
+            <button
+              type="button"
+              onClick={() => setViewMode('network')}
+              className={`w-full text-left px-3 py-2 rounded-md text-sm font-medium ${
+                viewMode === 'network' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'
+              }`}
+            >
+              ネットワーク
+            </button>
+            <button
+              type="button"
+              onClick={() => setViewMode('settings')}
+              className={`w-full flex items-center text-left px-3 py-2 rounded-md text-sm font-medium ${
+                viewMode === 'settings' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'
+              }`}
+            >
+              <Settings className="w-4 h-4 mr-2" />設定
+            </button>
+          </div>
+          <div className="p-4 border-t flex items-center space-x-2 text-sm">
+            <UserCircle className="w-4 h-4" />
+            <span>ゲスト</span>
+          </div>
+          <button
+            type="button"
+            onClick={() => setSidebarOpen(false)}
+            className="absolute top-2 -right-3 p-1 bg-white border rounded-full shadow"
+          >
+            <ChevronLeft className="w-4 h-4" />
+          </button>
+        </aside>
+      ) : (
+        <div className="w-8 bg-white border-r flex flex-col items-center">
+          <button
+            type="button"
+            onClick={() => setSidebarOpen(true)}
+            className="mt-2 p-1 rounded hover:bg-gray-100"
+          >
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+
+      <div className="flex-1 flex flex-col">
+        <div className="bg-white shadow-sm border-b">
+          <div className="max-w-6xl mx-auto px-4 py-4">
+            <div className="flex items-center space-x-4">
+              <button
+                type="button"
+                onClick={resetSearch}
+                className="flex items-center space-x-2 focus:outline-none"
+              >
+                <FileText className="w-8 h-8 text-blue-600" />
+                <h1 className="text-2xl font-bold text-gray-800">Paper Search</h1>
+              </button>
+              <div className="text-sm text-gray-500">学術論文検索エンジン</div>
+            </div>
           </div>
         </div>
-      </div>
 
       <div className="max-w-4xl mx-auto px-4 py-8">
         <div className="bg-white rounded-lg shadow-sm border p-6">
@@ -247,62 +303,8 @@ const PaperSearchUI = () => {
       </div>
 
       {isSearched && (
-        <div className="max-w-6xl mx-auto px-4 pb-8 flex">
-          {sidebarOpen ? (
-            <aside className="w-48 mr-6 flex flex-col">
-              <div className="bg-white rounded-lg shadow-sm border p-4 space-y-2 flex-1">
-                <button
-                  type="button"
-                  onClick={() => setViewMode('results')}
-                  className={`w-full text-left px-3 py-2 rounded-md text-sm font-medium ${
-                    viewMode === 'results' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'
-                  }`}
-                >
-                  検索結果
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setViewMode('network')}
-                  className={`w-full text-left px-3 py-2 rounded-md text-sm font-medium ${
-                    viewMode === 'network' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'
-                  }`}
-                >
-                  ネットワーク
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setViewMode('settings')}
-                  className={`w-full flex items-center text-left px-3 py-2 rounded-md text-sm font-medium ${
-                    viewMode === 'settings' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'
-                  }`}
-                >
-                  <Settings className="w-4 h-4 mr-2" />設定
-                </button>
-              </div>
-              <div className="bg-white rounded-lg shadow-sm border mt-2 p-3 flex items-center space-x-2 text-sm">
-                <UserCircle className="w-4 h-4" />
-                <span>ゲスト</span>
-              </div>
-              <button
-                type="button"
-                onClick={() => setSidebarOpen(false)}
-                className="mt-2 self-end text-gray-500 hover:text-gray-700"
-              >
-                <ChevronLeft className="w-4 h-4" />
-              </button>
-            </aside>
-          ) : (
-            <div className="mr-6">
-              <button
-                type="button"
-                onClick={() => setSidebarOpen(true)}
-                className="p-2 bg-white border rounded shadow-sm"
-              >
-                <ChevronRight className="w-4 h-4" />
-              </button>
-            </div>
-          )}
-          <div className="flex-1">
+        <div className="max-w-6xl mx-auto px-4 pb-8">
+          <div>
             {viewMode === 'results' && (
               <>
                 <div className="mb-4 text-sm text-gray-600">{searchResults.length} 件の論文が見つかりました</div>

--- a/frontend/src/PaperSearchUI.jsx
+++ b/frontend/src/PaperSearchUI.jsx
@@ -1,11 +1,25 @@
 import React, { useState } from 'react';
-import { Search, X, FileText, Calendar, Users, ExternalLink, Eye, Star } from 'lucide-react';
+import {
+  Search,
+  X,
+  FileText,
+  Calendar,
+  Users,
+  ExternalLink,
+  Eye,
+  Star,
+  Settings,
+  UserCircle,
+  ChevronLeft,
+  ChevronRight
+} from 'lucide-react';
 
 const PaperSearchUI = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState([]);
   const [isSearched, setIsSearched] = useState(false);
   const [viewMode, setViewMode] = useState('results');
+  const [sidebarOpen, setSidebarOpen] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [searchMode, setSearchMode] = useState('keyword');
   const [filters, setFilters] = useState({
@@ -234,28 +248,60 @@ const PaperSearchUI = () => {
 
       {isSearched && (
         <div className="max-w-6xl mx-auto px-4 pb-8 flex">
-          <aside className="w-48 mr-6">
-            <div className="bg-white rounded-lg shadow-sm border p-4 space-y-2">
+          {sidebarOpen ? (
+            <aside className="w-48 mr-6 flex flex-col">
+              <div className="bg-white rounded-lg shadow-sm border p-4 space-y-2 flex-1">
+                <button
+                  type="button"
+                  onClick={() => setViewMode('results')}
+                  className={`w-full text-left px-3 py-2 rounded-md text-sm font-medium ${
+                    viewMode === 'results' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'
+                  }`}
+                >
+                  検索結果
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setViewMode('network')}
+                  className={`w-full text-left px-3 py-2 rounded-md text-sm font-medium ${
+                    viewMode === 'network' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'
+                  }`}
+                >
+                  ネットワーク
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setViewMode('settings')}
+                  className={`w-full flex items-center text-left px-3 py-2 rounded-md text-sm font-medium ${
+                    viewMode === 'settings' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'
+                  }`}
+                >
+                  <Settings className="w-4 h-4 mr-2" />設定
+                </button>
+              </div>
+              <div className="bg-white rounded-lg shadow-sm border mt-2 p-3 flex items-center space-x-2 text-sm">
+                <UserCircle className="w-4 h-4" />
+                <span>ゲスト</span>
+              </div>
               <button
                 type="button"
-                onClick={() => setViewMode('results')}
-                className={`w-full text-left px-3 py-2 rounded-md text-sm font-medium ${
-                  viewMode === 'results' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'
-                }`}
+                onClick={() => setSidebarOpen(false)}
+                className="mt-2 self-end text-gray-500 hover:text-gray-700"
               >
-                検索結果
+                <ChevronLeft className="w-4 h-4" />
               </button>
+            </aside>
+          ) : (
+            <div className="mr-6">
               <button
                 type="button"
-                onClick={() => setViewMode('network')}
-                className={`w-full text-left px-3 py-2 rounded-md text-sm font-medium ${
-                  viewMode === 'network' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'
-                }`}
+                onClick={() => setSidebarOpen(true)}
+                className="p-2 bg-white border rounded shadow-sm"
               >
-                ネットワーク
+                <ChevronRight className="w-4 h-4" />
               </button>
             </div>
-          </aside>
+          )}
           <div className="flex-1">
             {viewMode === 'results' && (
               <>
@@ -334,6 +380,11 @@ const PaperSearchUI = () => {
             {viewMode === 'network' && (
               <div className="bg-white rounded-lg shadow-sm border p-6 text-center text-gray-600">
                 ネットワーク表示はまだ実装されていません
+              </div>
+            )}
+            {viewMode === 'settings' && (
+              <div className="bg-white rounded-lg shadow-sm border p-6 text-center text-gray-600">
+                設定画面はまだ実装されていません
               </div>
             )}
           </div>

--- a/frontend/src/PaperSearchUI.jsx
+++ b/frontend/src/PaperSearchUI.jsx
@@ -5,6 +5,7 @@ const PaperSearchUI = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState([]);
   const [isSearched, setIsSearched] = useState(false);
+  const [viewMode, setViewMode] = useState('results');
   const [isLoading, setIsLoading] = useState(false);
   const [searchMode, setSearchMode] = useState('keyword');
   const [filters, setFilters] = useState({
@@ -120,6 +121,11 @@ const PaperSearchUI = () => {
     setSearchQuery('');
     setIsSearched(false);
     setSearchResults([]);
+    setViewMode('results');
+  };
+
+  const resetSearch = () => {
+    clearSearch();
   };
 
   return (
@@ -127,10 +133,14 @@ const PaperSearchUI = () => {
       <div className="bg-white shadow-sm border-b">
         <div className="max-w-6xl mx-auto px-4 py-4">
           <div className="flex items-center space-x-4">
-            <div className="flex items-center space-x-2">
+            <button
+              type="button"
+              onClick={resetSearch}
+              className="flex items-center space-x-2 focus:outline-none"
+            >
               <FileText className="w-8 h-8 text-blue-600" />
               <h1 className="text-2xl font-bold text-gray-800">Paper Search</h1>
-            </div>
+            </button>
             <div className="text-sm text-gray-500">学術論文検索エンジン</div>
           </div>
         </div>
@@ -223,11 +233,36 @@ const PaperSearchUI = () => {
       </div>
 
       {isSearched && (
-        <div className="max-w-4xl mx-auto px-4 pb-8">
-          <div className="mb-4 text-sm text-gray-600">{searchResults.length} 件の論文が見つかりました</div>
-          <div className="space-y-6">
-            {searchResults.map((paper) => (
-              <div key={paper.id} className="bg-white rounded-lg shadow-sm border p-6 hover:shadow-md transition-shadow">
+        <div className="max-w-6xl mx-auto px-4 pb-8 flex">
+          <aside className="w-48 mr-6">
+            <div className="bg-white rounded-lg shadow-sm border p-4 space-y-2">
+              <button
+                type="button"
+                onClick={() => setViewMode('results')}
+                className={`w-full text-left px-3 py-2 rounded-md text-sm font-medium ${
+                  viewMode === 'results' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'
+                }`}
+              >
+                検索結果
+              </button>
+              <button
+                type="button"
+                onClick={() => setViewMode('network')}
+                className={`w-full text-left px-3 py-2 rounded-md text-sm font-medium ${
+                  viewMode === 'network' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'
+                }`}
+              >
+                ネットワーク
+              </button>
+            </div>
+          </aside>
+          <div className="flex-1">
+            {viewMode === 'results' && (
+              <>
+                <div className="mb-4 text-sm text-gray-600">{searchResults.length} 件の論文が見つかりました</div>
+                <div className="space-y-6">
+                  {searchResults.map((paper) => (
+                    <div key={paper.id} className="bg-white rounded-lg shadow-sm border p-6 hover:shadow-md transition-shadow">
                 <div className="flex justify-between items-start mb-3">
                   <h3 className="text-xl font-semibold text-gray-900 hover:text-blue-600 cursor-pointer mb-2">{paper.title}</h3>
                   <div className="flex items-center space-x-2 text-sm text-gray-500">
@@ -293,6 +328,15 @@ const PaperSearchUI = () => {
               <p className="text-gray-500">別のキーワードで検索してみてください</p>
             </div>
           )}
+        </>
+      )}
+
+            {viewMode === 'network' && (
+              <div className="bg-white rounded-lg shadow-sm border p-6 text-center text-gray-600">
+                ネットワーク表示はまだ実装されていません
+              </div>
+            )}
+          </div>
         </div>
       )}
 

--- a/frontend/src/PaperSearchUI.jsx
+++ b/frontend/src/PaperSearchUI.jsx
@@ -6,6 +6,7 @@ const PaperSearchUI = () => {
   const [searchResults, setSearchResults] = useState([]);
   const [isSearched, setIsSearched] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [searchMode, setSearchMode] = useState('keyword');
   const [filters, setFilters] = useState({
     year: '',
     category: '',
@@ -137,6 +138,31 @@ const PaperSearchUI = () => {
 
       <div className="max-w-4xl mx-auto px-4 py-8">
         <div className="bg-white rounded-lg shadow-sm border p-6">
+          <div className="mb-4 flex space-x-4">
+            <button
+              type="button"
+              onClick={() => setSearchMode('keyword')}
+              className={`px-3 py-1 rounded-md text-sm font-medium ${
+                searchMode === 'keyword'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 text-gray-700'
+              }`}
+            >
+              キーワード検索
+            </button>
+            <button
+              type="button"
+              onClick={() => setSearchMode('ai')}
+              className={`px-3 py-1 rounded-md text-sm font-medium ${
+                searchMode === 'ai'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 text-gray-700'
+              }`}
+            >
+              AI検索
+            </button>
+          </div>
+
           <div className="relative mb-4">
             <div className="relative flex items-center border border-gray-300 rounded-lg px-4 py-3 focus-within:border-blue-500 focus-within:ring-2 focus-within:ring-blue-200">
               <Search className="w-5 h-5 text-gray-400 mr-3" />
@@ -145,7 +171,7 @@ const PaperSearchUI = () => {
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 onKeyDown={(e) => e.key === 'Enter' && handleSearch(e)}
-                className="flex-1 outline-none text-gray-700 text-lg"
+                className="flex-1 outline-none text-gray-700 text-lg bg-white"
                 placeholder="論文のタイトル、著者、キーワードで検索..."
               />
               {searchQuery && (

--- a/frontend/src/PaperSearchUI.jsx
+++ b/frontend/src/PaperSearchUI.jsx
@@ -1,0 +1,310 @@
+import React, { useState } from 'react';
+import { Search, X, FileText, Calendar, Users, ExternalLink, Eye, Star } from 'lucide-react';
+
+const PaperSearchUI = () => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState([]);
+  const [isSearched, setIsSearched] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [filters, setFilters] = useState({
+    year: '',
+    category: '',
+    sortBy: 'relevance'
+  });
+
+  const mockPapers = [
+    {
+      id: 1,
+      title: 'Attention Is All You Need',
+      authors: ['Ashish Vaswani', 'Noam Shazeer', 'Niki Parmar', 'Jakob Uszkoreit'],
+      abstract:
+        'The dominant sequence transduction models are based on complex recurrent or convolutional neural networks that include an encoder and a decoder. The best performing models also connect the encoder and decoder through an attention mechanism. We propose a new simple network architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence and convolutions entirely.',
+      year: 2017,
+      venue: 'NIPS',
+      category: 'Machine Learning',
+      citations: 45230,
+      pdfUrl: 'https://arxiv.org/pdf/1706.03762.pdf',
+      arxivId: '1706.03762',
+      tags: ['transformer', 'attention', 'neural networks']
+    },
+    {
+      id: 2,
+      title: 'BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding',
+      authors: ['Jacob Devlin', 'Ming-Wei Chang', 'Kenton Lee', 'Kristina Toutanova'],
+      abstract:
+        'We introduce a new language representation model called BERT, which stands for Bidirectional Encoder Representations from Transformers. Unlike recent language representation models, BERT is designed to pre-train deep bidirectional representations from unlabeled text by jointly conditioning on both left and right context in all layers.',
+      year: 2019,
+      venue: 'NAACL',
+      category: 'Natural Language Processing',
+      citations: 32145,
+      pdfUrl: 'https://arxiv.org/pdf/1810.04805.pdf',
+      arxivId: '1810.04805',
+      tags: ['bert', 'pre-training', 'language model']
+    },
+    {
+      id: 3,
+      title: 'ResNet: Deep Residual Learning for Image Recognition',
+      authors: ['Kaiming He', 'Xiangyu Zhang', 'Shaoqing Ren', 'Jian Sun'],
+      abstract:
+        'Deeper neural networks are more difficult to train. We present a residual learning framework to ease the training of networks that are substantially deeper than those used previously. We explicitly reformulate the layers as learning residual functions with reference to the layer inputs, instead of learning unreferenced functions.',
+      year: 2016,
+      venue: 'CVPR',
+      category: 'Computer Vision',
+      citations: 89123,
+      pdfUrl: 'https://arxiv.org/pdf/1512.03385.pdf',
+      arxivId: '1512.03385',
+      tags: ['resnet', 'deep learning', 'image recognition']
+    },
+    {
+      id: 4,
+      title: 'Generative Adversarial Networks',
+      authors: ['Ian J. Goodfellow', 'Jean Pouget-Abadie', 'Mehdi Mirza'],
+      abstract:
+        'We propose a new framework for estimating generative models via an adversarial process, in which we simultaneously train two models: a generative model G that captures the data distribution, and a discriminative model D that estimates the probability that a sample came from the training data rather than G.',
+      year: 2014,
+      venue: 'NIPS',
+      category: 'Machine Learning',
+      citations: 67891,
+      pdfUrl: 'https://arxiv.org/pdf/1406.2661.pdf',
+      arxivId: '1406.2661',
+      tags: ['gan', 'generative model', 'adversarial training']
+    }
+  ];
+
+  const categories = ['All', 'Machine Learning', 'Computer Vision', 'Natural Language Processing', 'Robotics', 'Theory'];
+  const sortOptions = [
+    { value: 'relevance', label: '関連度' },
+    { value: 'citations', label: '被引用数' },
+    { value: 'year', label: '年度（新しい順）' },
+    { value: 'year_old', label: '年度（古い順）' }
+  ];
+
+  const handleSearch = (e) => {
+    e.preventDefault();
+    if (searchQuery.trim()) {
+      setIsLoading(true);
+      setTimeout(() => {
+        let results = mockPapers.filter((paper) =>
+          paper.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          paper.abstract.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          paper.authors.some((author) => author.toLowerCase().includes(searchQuery.toLowerCase())) ||
+          paper.tags.some((tag) => tag.toLowerCase().includes(searchQuery.toLowerCase()))
+        );
+
+        if (filters.category && filters.category !== 'All') {
+          results = results.filter((paper) => paper.category === filters.category);
+        }
+
+        results.sort((a, b) => {
+          switch (filters.sortBy) {
+            case 'citations':
+              return b.citations - a.citations;
+            case 'year':
+              return b.year - a.year;
+            case 'year_old':
+              return a.year - b.year;
+            default:
+              return 0;
+          }
+        });
+
+        setSearchResults(results);
+        setIsSearched(true);
+        setIsLoading(false);
+      }, 800);
+    }
+  };
+
+  const clearSearch = () => {
+    setSearchQuery('');
+    setIsSearched(false);
+    setSearchResults([]);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="bg-white shadow-sm border-b">
+        <div className="max-w-6xl mx-auto px-4 py-4">
+          <div className="flex items-center space-x-4">
+            <div className="flex items-center space-x-2">
+              <FileText className="w-8 h-8 text-blue-600" />
+              <h1 className="text-2xl font-bold text-gray-800">Paper Search</h1>
+            </div>
+            <div className="text-sm text-gray-500">学術論文検索エンジン</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <div className="bg-white rounded-lg shadow-sm border p-6">
+          <div className="relative mb-4">
+            <div className="relative flex items-center border border-gray-300 rounded-lg px-4 py-3 focus-within:border-blue-500 focus-within:ring-2 focus-within:ring-blue-200">
+              <Search className="w-5 h-5 text-gray-400 mr-3" />
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleSearch(e)}
+                className="flex-1 outline-none text-gray-700 text-lg"
+                placeholder="論文のタイトル、著者、キーワードで検索..."
+              />
+              {searchQuery && (
+                <button type="button" onClick={clearSearch} className="p-1 hover:bg-gray-100 rounded-full mr-2">
+                  <X className="w-4 h-4 text-gray-400" />
+                </button>
+              )}
+              <button
+                onClick={handleSearch}
+                disabled={!searchQuery.trim() || isLoading}
+                className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white px-6 py-2 rounded-md font-medium transition-colors"
+              >
+                {isLoading ? '検索中...' : '検索'}
+              </button>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-4 items-center">
+            <div className="flex items-center space-x-2">
+              <label className="text-sm font-medium text-gray-700">カテゴリ:</label>
+              <select
+                value={filters.category}
+                onChange={(e) => setFilters({ ...filters, category: e.target.value })}
+                className="border border-gray-300 rounded px-3 py-1 text-sm"
+              >
+                {categories.map((cat) => (
+                  <option key={cat} value={cat === 'All' ? '' : cat}>
+                    {cat}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-center space-x-2">
+              <label className="text-sm font-medium text-gray-700">ソート:</label>
+              <select
+                value={filters.sortBy}
+                onChange={(e) => setFilters({ ...filters, sortBy: e.target.value })}
+                className="border border-gray-300 rounded px-3 py-1 text-sm"
+              >
+                {sortOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {isSearched && (
+        <div className="max-w-4xl mx-auto px-4 pb-8">
+          <div className="mb-4 text-sm text-gray-600">{searchResults.length} 件の論文が見つかりました</div>
+          <div className="space-y-6">
+            {searchResults.map((paper) => (
+              <div key={paper.id} className="bg-white rounded-lg shadow-sm border p-6 hover:shadow-md transition-shadow">
+                <div className="flex justify-between items-start mb-3">
+                  <h3 className="text-xl font-semibold text-gray-900 hover:text-blue-600 cursor-pointer mb-2">{paper.title}</h3>
+                  <div className="flex items-center space-x-2 text-sm text-gray-500">
+                    <Star className="w-4 h-4" />
+                    <span>{paper.citations.toLocaleString()} 引用</span>
+                  </div>
+                </div>
+
+                <div className="flex items-center space-x-4 text-sm text-gray-600 mb-3">
+                  <div className="flex items-center space-x-1">
+                    <Users className="w-4 h-4" />
+                    <span>
+                      {paper.authors.slice(0, 3).join(', ')}
+                      {paper.authors.length > 3 ? ' et al.' : ''}
+                    </span>
+                  </div>
+                  <div className="flex items-center space-x-1">
+                    <Calendar className="w-4 h-4" />
+                    <span>
+                      {paper.year} • {paper.venue}
+                    </span>
+                  </div>
+                  <span className="bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-xs">{paper.category}</span>
+                </div>
+
+                <p className="text-gray-700 mb-4 leading-relaxed">{paper.abstract}</p>
+
+                <div className="flex items-center justify-between">
+                  <div className="flex flex-wrap gap-2">
+                    {paper.tags.map((tag) => (
+                      <span key={tag} className="bg-gray-100 text-gray-600 px-2 py-1 rounded text-xs">#{tag}</span>
+                    ))}
+                  </div>
+                  <div className="flex items-center space-x-3">
+                    <a
+                      href={paper.pdfUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center space-x-1 text-blue-600 hover:text-blue-800 text-sm"
+                    >
+                      <Eye className="w-4 h-4" />
+                      <span>PDF</span>
+                    </a>
+                    <a
+                      href={`https://arxiv.org/abs/${paper.arxivId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center space-x-1 text-blue-600 hover:text-blue-800 text-sm"
+                    >
+                      <ExternalLink className="w-4 h-4" />
+                      <span>arXiv</span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {searchResults.length === 0 && !isLoading && (
+            <div className="text-center py-12">
+              <FileText className="w-16 h-16 text-gray-300 mx-auto mb-4" />
+              <h3 className="text-lg font-medium text-gray-900 mb-2">検索結果が見つかりません</h3>
+              <p className="text-gray-500">別のキーワードで検索してみてください</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {!isSearched && (
+        <div className="max-w-4xl mx-auto px-4">
+          <div className="bg-white rounded-lg shadow-sm border p-8 text-center">
+            <FileText className="w-16 h-16 text-blue-600 mx-auto mb-4" />
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">論文を検索しましょう</h2>
+            <p className="text-gray-600 mb-6">タイトル、著者名、キーワードで最新の学術論文を検索できます</p>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 text-left">
+              <div className="flex items-start space-x-3">
+                <Search className="w-6 h-6 text-blue-600 mt-1" />
+                <div>
+                  <h3 className="font-medium text-gray-900 mb-1">高度な検索</h3>
+                  <p className="text-sm text-gray-600">タイトル、要約、著者名から包括的に検索</p>
+                </div>
+              </div>
+              <div className="flex items-start space-x-3">
+                <Star className="w-6 h-6 text-blue-600 mt-1" />
+                <div>
+                  <h3 className="font-medium text-gray-900 mb-1">被引用数順</h3>
+                  <p className="text-sm text-gray-600">影響力の高い論文を優先的に表示</p>
+                </div>
+              </div>
+              <div className="flex items-start space-x-3">
+                <FileText className="w-6 h-6 text-blue-600 mt-1" />
+                <div>
+                  <h3 className="font-medium text-gray-900 mb-1">PDF直接アクセス</h3>
+                  <p className="text-sm text-gray-600">論文PDFに直接アクセス可能</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PaperSearchUI;
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,68 +1,7 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  background-color: #f9fafb;
+  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
 }


### PR DESCRIPTION
## Summary
- implement new `PaperSearchUI` component
- simplify `App` to render the new UI
- add Tailwind CDN and lucide-react

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68440c052fe8832cb5059b9f0370b1cf