### PR TITLE
Add simple paper network view

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,9 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "cytoscape": "^3.32.0",
         "react": "^19.1.0",
+        "react-cytoscapejs": "^2.0.0",
         "react-dom": "^19.1.0"
       },
       "devDependencies": {
@@ -1622,6 +1624,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.32.0.tgz",
+      "integrity": "sha512-5JHBC9n75kz5851jeklCPmZWcg3hUe6sjqJvyk3+hVqFaKcHwHgxsjeN1yLmggoUc6STbtm9/NQyabQehfjvWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -2115,7 +2126,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -2225,6 +2235,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2287,6 +2309,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2430,6 +2461,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2449,6 +2491,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-cytoscapejs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-cytoscapejs/-/react-cytoscapejs-2.0.0.tgz",
+      "integrity": "sha512-t3SSl1DQy7+JQjN+8QHi1anEJlM3i3aAeydHTsJwmjo/isyKK7Rs7oCvU6kZsB9NwZidzZQR21Vm2PcBLG/Tjg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.19",
+        "react": ">=15.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -2460,6 +2515,12 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "cytoscape": "^3.32.0",
     "react": "^19.1.0",
+    "react-cytoscapejs": "^2.0.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -28,3 +28,8 @@
   padding: 0.5rem;
   margin-bottom: 0.5rem;
 }
+
+.paper-network {
+  margin-top: 1rem;
+  border: 1px solid #ccc;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import SearchBar from './components/SearchBar.jsx'
 import SearchOptions from './components/SearchOptions.jsx'
 import PaperList from './components/PaperList.jsx'
 import ChatPanel from './components/ChatPanel.jsx'
+import PaperNetwork from './components/PaperNetwork.jsx'
 
 function App() {
   const [options, setOptions] = useState({})
@@ -11,7 +12,7 @@ function App() {
   const [loading, setLoading] = useState(false)
   const [selectedPaper, setSelectedPaper] = useState(null)
 
-  const handleSearch = async ({ query, mode }) => {
+  const handleSearch = async ({ query }) => {
     setLoading(true)
     setSelectedPaper(null)
     try {
@@ -37,9 +38,10 @@ function App() {
       <SearchBar onSearch={handleSearch} />
       <SearchOptions onChange={setOptions} />
       {loading && <p>検索中...</p>}
+      <PaperNetwork papers={papers} />
       <PaperList papers={papers} onSelect={setSelectedPaper} />
       <ChatPanel paper={selectedPaper} />
-    </div>
+      </div>
   )
 }
 

--- a/frontend/src/components/PaperNetwork.jsx
+++ b/frontend/src/components/PaperNetwork.jsx
@@ -1,0 +1,29 @@
+import CytoscapeComponent from 'react-cytoscapejs'
+import { useMemo } from 'react'
+
+export default function PaperNetwork({ papers }) {
+  const elements = useMemo(() => {
+    const els = []
+    els.push({ data: { id: 'center', label: 'search' }, position: { x: 0, y: 0 } })
+    const radius = 200
+    const angleStep = (2 * Math.PI) / (papers?.length || 1)
+    papers?.forEach((p, i) => {
+      const id = `p${i}`
+      const angle = i * angleStep
+      const x = radius * Math.cos(angle)
+      const y = radius * Math.sin(angle)
+      els.push({
+        data: { id, label: p.title },
+        position: { x, y }
+      })
+      els.push({ data: { id: `e${i}`, source: 'center', target: id } })
+    })
+    return els
+  }, [papers])
+
+  return (
+    <div className="paper-network">
+      <CytoscapeComponent elements={elements} style={{ width: '800px', height: '600px' }} layout={{ name: 'preset' }} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `react-cytoscapejs` and `cytoscape`
- show a paper network graph beside the list view
- tweak CSS for the new component

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684429ecb518832c815279e22fbf4f0b